### PR TITLE
Fix loader initialization and chunk loading

### DIFF
--- a/csv_to_rds/__init__.py
+++ b/csv_to_rds/__init__.py
@@ -1,0 +1,23 @@
+"""Public APIs for CSV to RDS package."""
+
+from .csv_to_rds import (
+    CSVtoRDSLoader,
+    ConfigManager,
+    DatabaseManager,
+    DatabaseConfig,
+    ConfigurationError,
+    DatabaseError,
+    ValidationError,
+    validate_csv_file,
+)
+
+__all__ = [
+    "CSVtoRDSLoader",
+    "ConfigManager",
+    "DatabaseManager",
+    "DatabaseConfig",
+    "ConfigurationError",
+    "DatabaseError",
+    "ValidationError",
+    "validate_csv_file",
+]

--- a/tests/test_csv_to_rds.py
+++ b/tests/test_csv_to_rds.py
@@ -7,7 +7,7 @@ import os
 import pytest
 import pandas as pd
 import pymysql
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch, MagicMock, mock_open
 from csv_to_rds import (
     CSVtoRDSLoader,
     ConfigManager,


### PR DESCRIPTION
## Summary
- expose public APIs in `csv_to_rds` package
- make `DatabaseManager.connect` easier to test
- count processed rows directly in `load_data_in_chunks`
- delay loader configuration until initialization and make runtime imports patchable
- allow patching `validate_csv_file`
- fix unit tests to import `mock_open`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c64a03d08328ae4bbcb0bd3b410d